### PR TITLE
replicate behavior of NSMutableDictionary's removeObjectForKey:

### DIFF
--- a/M13OrderedDictionary.m
+++ b/M13OrderedDictionary.m
@@ -1072,9 +1072,7 @@
 
 - (void)removeEntry:(NSDictionary *)entry
 {
-    if (entry.count > 0) {
-        [self removeEntryWithObject:[entry.allValues objectAtIndex:0] pairedWithKey:[entry.allKeys objectAtIndex:0]];
-    }
+    [self removeEntryWithObject:[entry.allValues objectAtIndex:0] pairedWithKey:[entry.allKeys objectAtIndex:0]];
 }
 
 - (void)removeEntryWithObject:(id)object inRange:(NSRange)range


### PR DESCRIPTION
This is a fix for #19. These sanity checks are to replicate behavior of `NSMutableDictionary` methods `removeObjectForKey:` and `removeObjectForKeys:` which are documented to raise no exception for keys that do not exist.

This pull request also changes the behavior of these related methods to follow the same spirit:
`removeLastEntry`
`removeEntryWithObject:`
`removeEntryWithKey:`
`removeEntryWithObject:pairedWithKey:`
`removeEntry:`
`removeEntryWithObject:inRange:`
`removeEntryWithKey:inRange:`
`removeEntryWithObject:pairedWithKey:inRange:`
`removeEntry:inRange:`
`removeEntryWithObjectIdenticalTo:`
`removeEntryWithObjectIdenticalTo:inRange:`
`removeEntriesWithObjectsInArray:`
`removeEntriesWithKeysInArray:`

Of these, I would regard only the changes to `removeLastEntry` and the `inRange` methods to be debatable as to whether they should always silently return vs generate a range error, though in case of the `inRange` methods, when the range is out of bounds and not when the entry is not present. In all of those cases, I'll argue that its extra code that needs to be written to generate these exceptions rather than removing the code that this pull request adds.

This pull request does not change the behavior of `removeEntryAtIndex:` or `removeEntriesAtIndices:`, these still raise an range exception like the `NSMutableArray` method `removeObjectAtIndex:` does.
