### PR TITLE
Fix ivar typo

### DIFF
--- a/M13OrderedDictionary.m
+++ b/M13OrderedDictionary.m
@@ -107,7 +107,7 @@
 
 - (BOOL)containsObject:(id)object pairedWithKey:(id<NSCopying>)key
 {
-    if ([object containsObject:object] && [keys containsObject:key]) {
+    if ([objects containsObject:object] && [keys containsObject:key]) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
Original implementation send `containsObject:` message to the `object` argument accidentally. The message should be sent to `objects` ivar.